### PR TITLE
Fix a bug getting 0

### DIFF
--- a/h5view.py
+++ b/h5view.py
@@ -105,7 +105,7 @@ class Item(object):
     def __getattr__(self, name):
         """Access a child."""
         val = self.get(name)
-        if not val:
+        if val is None:
             val = self.kwargs.get(name)
         return val
         


### PR DESCRIPTION
Fix a bug that prevented one to get an attribute of an Item which has 0 value. (Or any value that bool() casts to False.) I'm not quite sure if this change has no side effect.

In the old version when `self.get(name)` returns the value 0.0, `__getattr__` also checked `self.kwargs.get(name)`, which returned None. Where as if I used `.get(name)` directly the expected 0.0 was returned. I think this was also intended in `__getattr__`.
